### PR TITLE
Config loading

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include uvp/config.yml
 include uvp/data/bed_list.txt
 include uvp/data/excluded_loci.txt
 include uvp/data/lineage_markers.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
-include uvp/config.yml
 include uvp/data/bed_list.txt
 include uvp/data/excluded_loci.txt
 include uvp/data/lineage_markers.txt

--- a/README.md
+++ b/README.md
@@ -73,13 +73,44 @@ snpEff download m_tuberculosis_H37Rv
 ```
 
 ## Configuration
+The following configuration settings may be supplied in a configuration file instead of providing them as command-line arguments:
 
-You will need to edit the config.yml file to point to your kraken database.
+- Path to kraken database
+- Number of CPU threads for parallel execution
+
+The config file should be a valid `yaml` file with this structure:
+
+```yml
+directories:
+    krakendb: /data/ref_databases/kraken/minikraken
+other:
+    threads: 8
+```
+
+When UVP is installed, a `config.yml` file is stored in `lib/python<version>/site-packages/uvp/config.yml`. The user may edit that file to provide the appropriate configuration settings. Alternatively, a `config.yml` can be provided using the `-c` or `--config` flags when an analysis in initiated. A config file supplied using the `-c` or `--config` flag will override any settings stored in the installed config file.
+
+The `krakendb` and `threads` parameters can also be supplied directly using the `-k`/`--krakendb` and `-t`/`--threads` flags, respectively. If those flags are included when starting an analysis they will override any values in config files.
+
 
 ## Running the UVP
 
 Run the UVP using command line prompts as follows:
 
 ```
-uvp -q 'input fastq' -r 'path to H37Rv reference genome fasta file' -n 'sample name' -q2 'paired fastq file' -a -v 
+uvp \
+  -n 'sample name' \
+  -r 'path to H37Rv reference genome fasta file' \
+  -q 'input fastq' \
+  -q2 'paired fastq file' \
+  -a -v 
+```
+
+```
+uvp \
+  -c 'path to config file' \
+  -n 'sample name' \
+  -r 'path to H37Rv reference genome fasta file' \
+  -q 'input fastq' \
+  -q2 'paired fastq file' \
+  -a -v 
 ```

--- a/README.md
+++ b/README.md
@@ -102,8 +102,11 @@ uvp \
   -r 'path to H37Rv reference genome fasta file' \
   -q 'input fastq' \
   -q2 'paired fastq file' \
-  -a -v 
+  --annotate \
+  --verbose 
 ```
+
+When passing a config file, use the `-c` or `--config` flag:
 
 ```
 uvp \
@@ -112,5 +115,21 @@ uvp \
   -r 'path to H37Rv reference genome fasta file' \
   -q 'input fastq' \
   -q2 'paired fastq file' \
-  -a -v 
+  --annotate \
+  --verbose 
 ```
+
+...or set the krakendb and threads parameters directly on the command-line:
+
+```
+uvp \
+  -n 'sample name' \
+  -r 'path to H37Rv reference genome fasta file' \
+  -q 'input fastq' \
+  -q2 'paired fastq file' \
+  --krakendb 'path to kraken database' \
+  --threads 16 \
+  --annotate \
+  --verbose 
+```
+

--- a/bin/uvp
+++ b/bin/uvp
@@ -17,6 +17,12 @@ import yaml
 import uvp
 from uvp.snp import Snp
 
+
+class TagNonDefault(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values)
+        setattr(namespace, self.dest+'_nondefault', True)
+
 def parse_args():
     
     parser = argparse.ArgumentParser(prog='uvp', conflict_handler='resolve',
@@ -38,7 +44,7 @@ def parse_args():
     group5 = parser.add_argument_group('Annotation', 'Use snpEff to annotate VCF file')
     group5.add_argument('-a', '--annotate', action='store_true', help='Run snpEff functional annotation.')
     group6 = parser.add_argument_group('Optional', '')
-    group6.add_argument('-t', '--threads', help='Num CPU threads for parallel execution', default=1)
+    group6.add_argument('-t', '--threads', help='Num CPU threads for parallel execution', default=1, action=TagNonDefault)
     group6.add_argument('-k', '--krakendb', help='Path to kraken database', metavar="STRING")
     group6.add_argument('-c', '--config', help='Config file', metavar="STRING")
     group6.add_argument('-v', '--verbose', action='store_true', help='Produce status updates of the run.') 
@@ -125,14 +131,14 @@ def parse_args():
     if not args.krakendb:
         args.krakendb = config['directories']['krakendb']
 
-    if not args.threads:
+    if not hasattr(args, 'threads_nondefault') :
         args.threads = config['other']['threads']
 
     return (args, paired)
 
 def main():
     (args, paired) = parse_args()
-        
+
     # All is well let's get started!
     s = Snp(
             input = args.fastq,

--- a/bin/uvp
+++ b/bin/uvp
@@ -42,7 +42,7 @@ def parse_args():
     group6.add_argument('-c', '--config', help='Config file', metavar="STRING")
     group6.add_argument('-v', '--verbose', action='store_true', help='Produce status updates of the run.') 
     group6.add_argument('-h', '--help', action='help', help='Show this help message and exit')
-    group6.add_argument('--version', action='version', version='%(prog)s v2.6.0', 
+    group6.add_argument('--version', action='version', version='%(prog)s v2.7.0',
                         help='Show program\'s version number and exit')
    
     if len(sys.argv)==1:

--- a/bin/uvp
+++ b/bin/uvp
@@ -7,22 +7,18 @@ CPTR ReSeqTB Project - Critical Path Institute
 """
 from __future__ import print_function
 
-try:
-    from configparser import ConfigParser
-except ImportError:
-    from ConfigParser import ConfigParser
-
 import sys
 import os
 import re
-import argparse as ap
+import argparse
 import gzip
+import yaml
 
 from uvp.snp import Snp
 
 def parse_args():
     
-    parser = ap.ArgumentParser(prog='uvp', conflict_handler='resolve', 
+    parser = argparse.ArgumentParser(prog='uvp', conflict_handler='resolve',
                                description="UVP - Call SNPs and InDels")
     group1 = parser.add_argument_group('Input', '')
     group1.add_argument('-q', '--fastq', required=True, help='Input FASTQ file', metavar="STRING")
@@ -42,7 +38,7 @@ def parse_args():
     group5.add_argument('-a', action='store_true', help='Run snpEff functional annotation.')
     group6 = parser.add_argument_group('Optional', '')
     group6.add_argument('-t', '--threads', help='Num CPU threads for parallel execution', default=1)
-    group6.add_argument('-k', '--kraken-db', help='Path to kraken database', metavar="STRING")
+    group6.add_argument('-k', '--krakendb', help='Path to kraken database', metavar="STRING")
     group6.add_argument('-c', '--config', help='Config file', metavar="STRING")
     group6.add_argument('-v', '--verbose', action='store_true', help='Produce status updates of the run.') 
     group6.add_argument('-h', '--help', action='help', help='Show this help message and exit')
@@ -108,6 +104,18 @@ def parse_args():
         print(' '.join(sys.argv))
         print("")
 
+    if args.config:
+        with open(args.config, 'r') as configfile:
+            config = yaml.safe_load(configfile)
+
+    # Command-line arguments have higher
+    # priority than config file settings.
+    if not args.krakendb:
+        args.krakendb = config['directories']['krakendb']
+
+    if not args.threads:
+        args.threads = config['other']['threads']
+
     return (args, paired)
 
 def main():
@@ -115,18 +123,16 @@ def main():
         
     # All is well let's get started!
     s = Snp(
-        {
-            'fastq' = args.fastq,
-            'outdir' = args.outdir,
-            'reference' = args.reference,
-            'name' = args.name,
-            'paired' = paired,
-            'fastq2' = args.fastq2, 
-            'verbose' = args.verbose,
-            'krakendb' = krakendb,
-            'threads' = threads,
-            'argString' = ' '.join(sys.argv)
-        }
+            input = args.fastq,
+            outdir = args.outdir,
+            reference = args.reference,
+            name = args.name,
+            paired = paired,
+            input2 = args.fastq2,
+            verbose = args.verbose,
+            krakendb = args.krakendb,
+            threads = args.threads,
+            argString = ' '.join(sys.argv)
     )
 
     s.runVali()

--- a/bin/uvp
+++ b/bin/uvp
@@ -6,6 +6,12 @@ Author: Matthew Ezewudo
 CPTR ReSeqTB Project - Critical Path Institute
 """
 from __future__ import print_function
+
+try:
+    from configparser import ConfigParser
+except ImportError:
+    from ConfigParser import ConfigParser
+
 import sys
 import os
 import re
@@ -35,6 +41,9 @@ def parse_args():
     group5 = parser.add_argument_group('Annotation', 'Use snpEff to annotate VCF file')
     group5.add_argument('-a', action='store_true', help='Run snpEff functional annotation.')
     group6 = parser.add_argument_group('Optional', '')
+    group6.add_argument('-t', '--threads', help='Num CPU threads for parallel execution', default=1)
+    group6.add_argument('-k', '--kraken-db', help='Path to kraken database', metavar="STRING")
+    group6.add_argument('-c', '--config', help='Config file', metavar="STRING")
     group6.add_argument('-v', '--verbose', action='store_true', help='Produce status updates of the run.') 
     group6.add_argument('-h', '--help', action='help', help='Show this help message and exit')
     group6.add_argument('--version', action='version', version='%(prog)s v2.6.0', 
@@ -105,8 +114,20 @@ def main():
     (args, paired) = parse_args()
         
     # All is well let's get started!
-    s = Snp(args.fastq, args.outdir, args.reference, args.name, paired, args.fastq2, 
-                        args.verbose, ' '.join(sys.argv))
+    s = Snp(
+        {
+            'fastq' = args.fastq,
+            'outdir' = args.outdir,
+            'reference' = args.reference,
+            'name' = args.name,
+            'paired' = paired,
+            'fastq2' = args.fastq2, 
+            'verbose' = args.verbose,
+            'krakendb' = krakendb,
+            'threads' = threads,
+            'argString' = ' '.join(sys.argv)
+        }
+    )
 
     s.runVali()
     s.runKraken()

--- a/bin/uvp
+++ b/bin/uvp
@@ -14,6 +14,7 @@ import argparse
 import gzip
 import yaml
 
+import uvp
 from uvp.snp import Snp
 
 def parse_args():

--- a/bin/uvp
+++ b/bin/uvp
@@ -35,7 +35,7 @@ def parse_args():
     group4.add_argument('--gatk', action='store_true', help='Run GATK SNP / InDel calling. (Default)')
     group4.add_argument('--samtools', action='store_true', help='Run SamTools SNP / InDel calling.')
     group5 = parser.add_argument_group('Annotation', 'Use snpEff to annotate VCF file')
-    group5.add_argument('-a', action='store_true', help='Run snpEff functional annotation.')
+    group5.add_argument('-a', '--annotate', action='store_true', help='Run snpEff functional annotation.')
     group6 = parser.add_argument_group('Optional', '')
     group6.add_argument('-t', '--threads', help='Num CPU threads for parallel execution', default=1)
     group6.add_argument('-k', '--krakendb', help='Path to kraken database', metavar="STRING")

--- a/bin/uvp
+++ b/bin/uvp
@@ -104,10 +104,21 @@ def parse_args():
         print(' '.join(sys.argv))
         print("")
 
+    # A config file supplied on the command-line will
+    # be used with higher priority than the installed config file
     if args.config:
-        with open(args.config, 'r') as configfile:
-            config = yaml.safe_load(configfile)
+        config = args.config
+    else:
+        config = os.path.join(
+            os.path.dirname(uvp.__file__),
+            'config.yml'
+        )
+        
+    with open(config, 'r') as configfile:
+        config = yaml.safe_load(configfile)
 
+        
+    
     # Command-line arguments have higher
     # priority than config file settings.
     if not args.krakendb:

--- a/scripts/coverage_estimator.py
+++ b/scripts/coverage_estimator.py
@@ -27,6 +27,6 @@ fh1.close()
 av_depth = depth/count
 perc_cov = float((count/4411532.00)*100.00)
 perc_cov_str = "{0:.2f}".format(perc_cov)
-print("Unified Analysis Pipeline Version: UVPv2.6.0\n")
+print("Unified Analysis Pipeline Version: UVPv2.7.0\n")
 print("Average Genome Coverage Depth: " + str(av_depth))
 print("Percentage of Reference genome covered: " + perc_cov_str)

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     author_email='',
     license='MIT',
     packages=['uvp'],
+    include_package_data=True,
     scripts=[
         'bin/uvp',
         'bin/UVP',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='reseqtb-uvp',
-    version='2.6.0',
+    version='2.7.0',
     description='Mycobacterium tuberculosis next generation sequence analysis',
     url='http://github.com/CPTR-ReSeqTB/UVP',
     author='Matthew Ezewudo',

--- a/uvp/snp.py
+++ b/uvp/snp.py
@@ -115,7 +115,7 @@ class Snp():
         self.__del_parser      = "del_parse.py"
         self.mutationloci      = os.path.join(os.path.dirname(__file__), 'data', 'mutation_loci.txt')
         self.snplist           = os.path.join(os.path.dirname(__file__), 'data', 'snps.NC_000962.vcf')
-        self.__threads         = threads
+        self.__threads         = str(threads)
         
     """ Shell Execution Functions """
     def __CallCommand(self, program, command):
@@ -201,7 +201,7 @@ class Snp():
         if self.paired:
            self.__CallCommand(['kraken', self.kraken + "/kraken.txt"],[self.__kraken, '--db', 
                                self.__krakendb, '--gzip-compressed', self.input, self.input2,
-                               '--paired', '--fastq-input', '--threads', str(self.__threads), '--classified-out',
+                               '--paired', '--fastq-input', '--threads', self.__threads, '--classified-out',
                                 self.name + "_classified_Reads.fastq"])
            self.__CallCommand(['krakenreport', self.kraken + "/final_report.txt"],[self.__krakenreport, '--db',
                                self.__krakendb, self.kraken + "/kraken.txt"])

--- a/uvp/snp.py
+++ b/uvp/snp.py
@@ -18,22 +18,22 @@ from datetime import datetime
 
 class Snp():
 
-    def __init__(self, **kwargs):
-    """
-    Initializer for 'Snp'.
-    Required keyword arguments:
-      'input': Path to R1 fastq file
-      'input2': Path to R2 fastq file
-      'reference': Path to reference fasta file
-      'name': Sample name
-      'outdir': Path to output directory
-      'paired': Reads are from paired-end library (boolean)
-      'verbose': Verbose output (boolean)
-      'krakendb': Path to kraken database
-      'threads': Number of CPU threads for parallel execution
-      'argString': Argument string (for logging)
-    """
-        self.name               = kwargs['name']
+    def __init__(self, input, outdir, reference, name, paired, input2, verbose, krakendb, threads, argString):
+        """
+        Initializer for 'Snp'.
+        Required keyword arguments:
+          'input': Path to R1 fastq file
+          'input2': Path to R2 fastq file
+          'reference': Path to reference fasta file
+          'name': Sample name
+          'outdir': Path to output directory
+          'paired': Reads are from paired-end library (boolean)
+          'verbose': Verbose output (boolean)
+          'krakendb': Path to kraken database
+          'threads': Number of CPU threads for parallel execution
+          'argString': Argument string (for logging)
+        """
+        self.name               = name
         self.fOut1              = "Results"
         self.fOut               = self.fOut1 + "/" + outdir
         self.flog               = "QC"
@@ -44,10 +44,10 @@ class Snp():
         self.fastqc             = self.fOut + "/fastqc"
         self.qualimap           = self.fOut + "/qualimap"
         self.kraken             = self.fOut + "/kraken"
-        self.paired             = kwargs['paired']
-        self.input2             = kwargs['input2']
-        self.verbose            = kwargs['verbose']
-        self.reference          = kwargs['reference']
+        self.paired             = paired
+        self.input2             = input2
+        self.verbose            = verbose
+        self.reference          = reference
         self.__finalVCF         = ''
         self.__annotation       = ''
         self.__final_annotation = ''
@@ -85,7 +85,7 @@ class Snp():
         #fastq QC
         self.__fastqc          = "fastqc"
         self.__kraken          = "kraken"
-        self.__krakendb        = kwargs['krakendb']
+        self.__krakendb        = krakendb
         self.__krakenreport    = "kraken-report"
         self.__pigz            = "pigz"
         self.__unpigz          = "unpigz"
@@ -115,7 +115,7 @@ class Snp():
         self.__del_parser      = "del_parse.py"
         self.mutationloci      = os.path.join(os.path.dirname(__file__), 'data', 'mutation_loci.txt')
         self.snplist           = os.path.join(os.path.dirname(__file__), 'data', 'snps.NC_000962.vcf')
-        self.__threads         = kwargs['threads']
+        self.__threads         = threads
         
     """ Shell Execution Functions """
     def __CallCommand(self, program, command):
@@ -201,7 +201,7 @@ class Snp():
         if self.paired:
            self.__CallCommand(['kraken', self.kraken + "/kraken.txt"],[self.__kraken, '--db', 
                                self.__krakendb, '--gzip-compressed', self.input, self.input2,
-                               '--paired', '--fastq-input', '--threads', self.__threads, '--classified-out',
+                               '--paired', '--fastq-input', '--threads', str(self.__threads), '--classified-out',
                                 self.name + "_classified_Reads.fastq"])
            self.__CallCommand(['krakenreport', self.kraken + "/final_report.txt"],[self.__krakenreport, '--db',
                                self.__krakendb, self.kraken + "/kraken.txt"])

--- a/uvp/snp.py
+++ b/uvp/snp.py
@@ -18,10 +18,10 @@ from datetime import datetime
 
 class Snp():
 
-    def __init__(self, input, outdir, reference, name, paired, input2, verbose, krakendb, threads, argString):
+    def __init__(self, input, outdir, reference, name, paired, input2, verbose, argString, krakendb, threads):
         """
         Initializer for 'Snp'.
-        Required keyword arguments:
+        Required arguments:
           'input': Path to R1 fastq file
           'input2': Path to R2 fastq file
           'reference': Path to reference fasta file
@@ -29,9 +29,9 @@ class Snp():
           'outdir': Path to output directory
           'paired': Reads are from paired-end library (boolean)
           'verbose': Verbose output (boolean)
+          'argString': Argument string (for logging)
           'krakendb': Path to kraken database
           'threads': Number of CPU threads for parallel execution
-          'argString': Argument string (for logging)
         """
         self.name               = name
         self.fOut1              = "Results"

--- a/uvp/snp.py
+++ b/uvp/snp.py
@@ -12,17 +12,28 @@ import re
 import types
 import gzip
 import yaml
-try:
-    from configparser import ConfigParser
-except ImportError:
-    from ConfigParser import ConfigParser
+
 import io
 from datetime import datetime
 
 class Snp():
 
-    def __init__(self, input, outdir, reference, name, paired,input2, verbose, argString):
-        self.name               = name
+    def __init__(self, **kwargs):
+    """
+    Initializer for 'Snp'.
+    Required keyword arguments:
+      'input': Path to R1 fastq file
+      'input2': Path to R2 fastq file
+      'reference': Path to reference fasta file
+      'name': Sample name
+      'outdir': Path to output directory
+      'paired': Reads are from paired-end library (boolean)
+      'verbose': Verbose output (boolean)
+      'krakendb': Path to kraken database
+      'threads': Number of CPU threads for parallel execution
+      'argString': Argument string (for logging)
+    """
+        self.name               = kwargs['name']
         self.fOut1              = "Results"
         self.fOut               = self.fOut1 + "/" + outdir
         self.flog               = "QC"
@@ -33,10 +44,10 @@ class Snp():
         self.fastqc             = self.fOut + "/fastqc"
         self.qualimap           = self.fOut + "/qualimap"
         self.kraken             = self.fOut + "/kraken"
-        self.paired             = paired
-        self.input2             = input2
-        self.verbose            = verbose
-        self.reference          = reference
+        self.paired             = kwargs['paired']
+        self.input2             = kwargs['input2']
+        self.verbose            = kwargs['verbose']
+        self.reference          = kwargs['reference']
         self.__finalVCF         = ''
         self.__annotation       = ''
         self.__final_annotation = ''
@@ -61,9 +72,6 @@ class Snp():
         self.__CallCommand('mkdir', ['mkdir', '-p', self.qualimap])
         self.__CallCommand('mkdir', ['mkdir', '-p', self.kraken])
         self.__log     = self.fOut + "/" + self.name + ".log"
-
-        with open(os.path.join(os.path.dirname(__file__), "config.yml"), 'r') as ymlfile:
-             cfg       = yaml.safe_load(ymlfile)
         self.__lineage = self.fOut + "/" + self.name + ".lineage_report.txt"
         self.__logFH   = open(self.__log, 'w')
         self.__logFH.write(argString + "\n\n")
@@ -77,7 +85,7 @@ class Snp():
         #fastq QC
         self.__fastqc          = "fastqc"
         self.__kraken          = "kraken"
-        self.__krakendb        = cfg['directories']['krakendb']
+        self.__krakendb        = kwargs['krakendb']
         self.__krakenreport    = "kraken-report"
         self.__pigz            = "pigz"
         self.__unpigz          = "unpigz"
@@ -107,7 +115,7 @@ class Snp():
         self.__del_parser      = "del_parse.py"
         self.mutationloci      = os.path.join(os.path.dirname(__file__), 'data', 'mutation_loci.txt')
         self.snplist           = os.path.join(os.path.dirname(__file__), 'data', 'snps.NC_000962.vcf')
-        self.__threads         = cfg['other']['threads']
+        self.__threads         = kwargs['threads']
         
     """ Shell Execution Functions """
     def __CallCommand(self, program, command):


### PR DESCRIPTION
Fixes #25 

- Ensure that a default config file is installed when `uvp` is installed
- Provide more detailed documentation on configuration setup
- Allow users to provide a config file on the command-line using the `-c` or `--config` flags
- Allow users to provide the `krakendb` parameter directly on the command-line using the `-k` or `--krakendb` flags
- Allow users to provide the `threads` parameter directly on the command-line using the `-t` or `--threads` flags
- Move config parsing to the `uvp` executable